### PR TITLE
resolve warnings in protected route

### DIFF
--- a/client/src/components/ProtectedRoute.tsx
+++ b/client/src/components/ProtectedRoute.tsx
@@ -1,30 +1,17 @@
-import React from 'react';
-import { Route, useHistory } from 'react-router-dom';
+import { Route, RouteProps, Redirect } from 'react-router-dom';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import { useAuth } from '../context/useAuthContext';
 
-interface Props {
-  component: React.ComponentType<any>;
-  [x: string]: any;
-}
-
-const ProtectedRoute = ({ component: Component, ...rest }: Props): JSX.Element => {
+const ProtectedRoute = (routeProps: RouteProps): JSX.Element => {
   const { loggedInUser } = useAuth();
-  const history = useHistory();
 
   // render the page conditionally based on user being logged in
-  return (
-    <Route
-      {...rest}
-      render={(props) => {
-        if (loggedInUser === undefined) return <CircularProgress />;
-        if (!loggedInUser) {
-          history.push('login');
-        }
-        return <Component {...rest} {...props} />;
-      }}
-    />
-  );
+  if (loggedInUser === undefined) return <CircularProgress />;
+  if (!loggedInUser) {
+    return <Redirect to={{ pathname: '/login' }} />;
+  } else {
+    return <Route {...routeProps} />;
+  }
 };
 
 export default ProtectedRoute;


### PR DESCRIPTION
### What this PR does (required):
- Resolve the warning in protected route by using the RouteProps interface from react-router-dom

