### PR TITLE
Paginate messages #49

### DIFF
--- a/client/src/components/ChatBox/ChatBoard.tsx
+++ b/client/src/components/ChatBox/ChatBoard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Grid } from '@material-ui/core';
+import { Grid, Typography, CircularProgress } from '@material-ui/core';
 import useStyles from './useStyles';
 import { Message } from '../../interface/Conversation';
 import { fetchMessages } from '../../helpers/APICalls/Conversation';
@@ -145,13 +145,9 @@ const ChatBoard = ({ translate, newMessage, conversationId, primaryLanguage }: P
         next={fetchMoreData}
         inverse={true}
         hasMore={hasMore}
-        loader={<h4>Loading...</h4>}
+        loader={<CircularProgress style={{ alignSelf: 'center' }} />}
         scrollableTarget="scrollableDiv"
-        endMessage={
-          <p style={{ textAlign: 'center' }}>
-            <b>No more messages</b>
-          </p>
-        }
+        endMessage={<Typography className={classes.endMessages}>No more messages</Typography>}
       >
         <Grid container className={classes.board} direction="column">
           {sortedMessages.map((message) => {

--- a/client/src/components/ChatBox/ChatBox.tsx
+++ b/client/src/components/ChatBox/ChatBox.tsx
@@ -15,7 +15,7 @@ interface Props {
 const chatBox = ({ loggedInUser, socket }: Props): JSX.Element => {
   const primaryLanguage = loggedInUser.primaryLanguage;
   const classes = useStyles();
-
+  const currentUserId = '60a4086085cdae24a4f6a929';
   const [translate, setTranslate] = useState<boolean>(false);
   const [message, setMessages] = useState<Message>({
     message: 'Initial Startup',
@@ -29,8 +29,11 @@ const chatBox = ({ loggedInUser, socket }: Props): JSX.Element => {
 
   useEffect(() => {
     socket?.on('chat', (args) => {
+      if (args.user === currentUserId) {
+        return;
+      }
       const textMessage: Message = {
-        message: args.message,
+        message: `message from socket${args.message}`,
         _id: '45534',
         sender: args.user,
         language: 'en',
@@ -44,12 +47,15 @@ const chatBox = ({ loggedInUser, socket }: Props): JSX.Element => {
   }, [socket]);
 
   const handleMessage = (text: string) => {
+    if (!text) {
+      return;
+    }
     const textMessage: Message = {
       message: text,
       _id: '45534',
       sender: '60a4086085cdae24a4f6a929',
-      language: 'English',
-      translations: [{ language: 'English', translation: 'English' }],
+      language: 'en',
+      translations: [{ language: 'fr', translation: 'French Version of this text' }],
       updatedAt: new Date(Date.now()),
       createdAt: new Date(Date.now()),
     };
@@ -70,7 +76,12 @@ const chatBox = ({ loggedInUser, socket }: Props): JSX.Element => {
         <ChatHeader handleSwitch={handleSwitch} />
       </Box>
       <Box className={classes.chatboard}>
-        <ChatBoard translate={translate} primaryLanguage={primaryLanguage} newMessage={message} />
+        <ChatBoard
+          translate={translate}
+          primaryLanguage="fr"
+          conversationId="60b82138d6f2b00d4cd80c86"
+          newMessage={message}
+        />
       </Box>
       <Box className={classes.inputbox}>
         <InputBox handleMessage={handleMessage} />

--- a/client/src/components/ChatBox/useStyles.tsx
+++ b/client/src/components/ChatBox/useStyles.tsx
@@ -1,5 +1,5 @@
 import { makeStyles } from '@material-ui/core/styles';
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme) => ({
   header: {
     paddingTop: 20,
     width: '100%',
@@ -7,10 +7,10 @@ const useStyles = makeStyles(() => ({
   },
   board: {
     width: '100%',
-    height: '95%',
-    display: 'flex',
-    flexDirection: 'row',
-    overflowY: 'auto',
+    height: '100%%',
+    // display: 'flex',
+    // flexDirection: 'row',
+    // overflowY: 'auto',
   },
   chattingUserName: {
     fontSize: 20,
@@ -31,7 +31,7 @@ const useStyles = makeStyles(() => ({
     height: '10%',
   },
   chatboard: {
-    height: '70%',
+    height: '80vh',
   },
   inputbox: {
     height: '10%',
@@ -116,6 +116,31 @@ const useStyles = makeStyles(() => ({
   },
   messageSeparator: {
     height: 6,
+  },
+  scroller: {
+    '&:hover': {
+      '&::-webkit-scrollbar': {
+        display: 'inline',
+      },
+    },
+    '&::-webkit-scrollbar': {
+      display: 'none',
+      width: '5px',
+    },
+    '&::-webkit-scrollbar-track': {
+      borderRadius: theme.shape.borderRadius,
+      backgroundColor: '#ddd',
+    },
+    '&::-webkit-scrollbar-thumb': {
+      backgroundColor: '#666',
+      borderRadius: theme.shape.borderRadius,
+    },
+  },
+  scrollerWrapper: {
+    overflow: 'auto',
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
   },
 }));
 

--- a/client/src/components/ChatBox/useStyles.tsx
+++ b/client/src/components/ChatBox/useStyles.tsx
@@ -142,6 +142,11 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: 'column',
     height: '100%',
   },
+  endMessages: {
+    textAlign: 'center',
+    fontStyle: 'italic',
+    color: 'gray',
+  },
 }));
 
 export default useStyles;

--- a/client/src/helpers/APICalls/Conversation.ts
+++ b/client/src/helpers/APICalls/Conversation.ts
@@ -3,15 +3,17 @@ import { FetchMessagesApiData } from '../../interface/Conversation';
 
 interface Props {
   conversationId: string;
+  offset: number;
+  limit: number;
 }
 
-export async function fetchMessages({ conversationId }: Props): Promise<FetchMessagesApiData> {
+export async function fetchMessages({ conversationId, offset, limit }: Props): Promise<FetchMessagesApiData> {
   const fetchOptions: FetchOptions = {
     method: 'GET',
     credentials: 'include',
   };
 
-  return await fetch(`/users/messages/${conversationId}`, fetchOptions)
+  return await fetch(`/users/messages/${conversationId}?offset=${offset}&limit=${limit}`, fetchOptions)
     .then((res) => res.json())
     .catch(() => ({
       error: {

--- a/server/controllers/message.js
+++ b/server/controllers/message.js
@@ -7,7 +7,6 @@ const translateMessage = require("../utils/translateMessage");
 // @route GET /users/messages/:conversationId
 
 exports.getMessages = asyncHandler(async (req, res) => {
-  const userId = req.user.id;
   const conversationId = req.params.conversationId;
 
   if (!mongoose.Types.ObjectId.isValid(conversationId)) {
@@ -16,13 +15,48 @@ exports.getMessages = asyncHandler(async (req, res) => {
   }
 
   const conversation = await Conversation.findById(conversationId);
-  const currentUser = await User.findById(userId);
 
   if (conversation) {
     return res.status(200).json({ messages: conversation.messages });
   } else {
     res.status(404);
     throw new Error("No conversation found");
+  }
+});
+
+// @route GET /users/messages/:conversationId?offset&limit
+// Get a batch of messages if offset and limit is specified
+// Otherwise return all messages
+exports.getLimitedMessages = asyncHandler(async (req, res) => {
+  const conversationId = req.params.conversationId;
+  if (!mongoose.Types.ObjectId.isValid(conversationId)) {
+    res.status(400);
+    throw new Error("Conversation id is not valid");
+  }
+  let conversation;
+
+  if (req.query.offset && req.query.limit) {
+    const offset = parseInt(req.query.offset);
+    const limit = parseInt(req.query.limit);
+    conversation = await Conversation.findById(conversationId, {
+      messages: {
+        $slice: [offset, limit],
+      },
+    });
+  } else {
+    conversation = await Conversation.findById(conversationId);
+  }
+
+  if (!conversation) {
+    res.status(404);
+    throw new Error("No conversation is found");
+  }
+
+  if (conversation.messages) {
+    return res.status(200).json({ messages: conversation.messages });
+  } else {
+    res.status(400);
+    throw new Error("No more messages");
   }
 });
 
@@ -65,10 +99,15 @@ exports.postMessage = asyncHandler(async (req, res) => {
       {
         $push: {
           messages: {
-            sender: userId,
-            message,
-            language: fromLanguage,
-            translations,
+            $each: [
+              {
+                sender: userId,
+                message,
+                language: fromLanguage,
+                translations,
+              },
+            ],
+            $position: 0,
           },
         },
       },

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -8,12 +8,16 @@ const {
   postGroupChat,
   addUserToGroupChat,
 } = require("../controllers/conversation");
-const { getMessages, postMessage } = require("../controllers/message");
+const {
+  getMessages,
+  postMessage,
+  getLimitedMessages,
+} = require("../controllers/message");
 
 router.route("/").get(protect, searchUsers);
 router.route("/conversations").get(protect, getUserConversations);
 router.route("/conversation/:userId").post(protect, postUserConversation);
-router.route("/messages/:conversationId").get(protect, getMessages);
+router.route("/messages/:conversationId").get(protect, getLimitedMessages);
 router.route("/message/:conversationId").post(protect, postMessage);
 router.route("/groupchat").post(protect, postGroupChat);
 router.route("/groupchat/:groupChatId").post(protect, addUserToGroupChat);


### PR DESCRIPTION
### What this PR does (required):
- Paginated messages on the ChatBorad components
- Modified GET messages route so that optionally a batch of messages can be loaded for the purpose of pagination ( I'm not sure this is the most efficient approach because I'm currently using the $slice operator of mongoose, it's very simple code for sure :))
- Implemented pagination component such that paginate happens when scroll to the top (so that the lastest messages are always shown and paginate to see previous messages)
- Also modified the POST message route so that each time the lastest message is stored at the top of the list, for the convenience of slice operation
- Improved the translation logic with useEffect() hook

### Screenshots / Videos (required):
- GET messages with a offset and limit
![image](https://user-images.githubusercontent.com/44036753/120937466-cbcf8380-c6ca-11eb-8f1f-158d68f5cf6b.png)
- Pagination when loading more messages
![image](https://user-images.githubusercontent.com/44036753/120937508-0df8c500-c6cb-11eb-989d-86b3fa34a968.png)
- Top of the messages
![image](https://user-images.githubusercontent.com/44036753/120937518-1ea93b00-c6cb-11eb-93e5-3d7b6277c0c4.png)

