### PR TITLE
Hotfix username

### DIFF
--- a/client/src/components/AuthMenu/AuthMenu.tsx
+++ b/client/src/components/AuthMenu/AuthMenu.tsx
@@ -40,7 +40,10 @@ const AuthMenu = (): JSX.Element => {
     setOpenDialog(!openDialog);
     if (submitted) handleClose();
   };
-
+  const toggleInvitationsDialog = (submitted: boolean) => {
+    setOpenDialog(!openDialog);
+    if (submitted) handleClose();
+  };
   return (
     <Box>
       <IconButton aria-label="show auth menu" aria-controls="auth-menu" aria-haspopup="true" onClick={handleClick}>
@@ -65,6 +68,13 @@ const AuthMenu = (): JSX.Element => {
           open={openDialog}
           dialogControl={toggleProfileImageDialog}
           action={['Upload Profile Image', 'Submit']}
+          fetch={fetch}
+        />
+        <MenuItem onClick={() => toggleInvitationsDialog(false)}>Pending Invitations</MenuItem>
+        <FormDialog
+          open={openDialog}
+          dialogControl={toggleInvitationsDialog}
+          action={['Invitations', '']}
           fetch={fetch}
         />
       </Menu>

--- a/client/src/components/ChatSideBanner/ChatSideBanner.tsx
+++ b/client/src/components/ChatSideBanner/ChatSideBanner.tsx
@@ -16,6 +16,7 @@ interface Props {
 
 const ChatSideBanner = ({ loggedInUser, handleConversationId }: Props): JSX.Element => {
   const classes = useStyles();
+  const username = loggedInUser.email.split('@');
 
   return (
     <Grid
@@ -29,7 +30,7 @@ const ChatSideBanner = ({ loggedInUser, handleConversationId }: Props): JSX.Elem
           <AvatarDisplay loggedIn user={loggedInUser} />
           <Typography className={classes.userName}>
             {/* {loggedInUser.username} we need to add username from start up here */}
-            Thomas
+            {username[0]}
           </Typography>
         </Grid>
         <Box style={{ paddingTop: '30px' }}>


### PR DESCRIPTION
### What this PR does:
- Moves Invitations to Auth Menu
- Creates a temporary fix for Usernames Displaying

### Screenshots / Videos:
![Screen Shot 2021-09-05 at 11 08 21 AM](https://user-images.githubusercontent.com/58789967/132131701-3d8debed-9627-4614-92a2-9bed2f362b43.png)
![Screen Shot 2021-09-05 at 11 08 43 AM](https://user-images.githubusercontent.com/58789967/132131726-7d7cb5e5-6b0c-4dfb-b26a-c0e2b9bff63f.png)

### Any information needed to test this feature (required):
1. Login with user credentials
 2. Open Auth Menu

### Any issues with the current functionality (optional):
User name needs to be properly implemented as we currently are creating user names by splicing the name before '@email.com'
